### PR TITLE
Fix Priority Color to match and add Issue Badges

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,7 +1,7 @@
 ## Tags
 
 - name: "-priority"
-  color: "d73a4a" # red
+  color: "d93f0b" # red
   description: "Take a look at this soon!"
 - name: "good first issue"
   color: "F4B0F5" # pink

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ version: 0.7.0-SNAPSHOT
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/devlinjunker/template.hapi.rest/Doc%20Build%20and%20Wiki%20Sync%20on%20Merge%20to%20%60master%60)](https://github.com/devlinjunker/template.hapi.rest/actions)  
 ![Dependency Check by David](https://img.shields.io/david/devlinjunker/template.hapi.rest)
 ![Dev Dependency Check by David](https://img.shields.io/david/dev/devlinjunker/template.hapi.rest)   
-[![OpenAPI/Swagger Validator](https://img.shields.io/swagger/valid/3.0?label=openapi&specUrl=https%3A%2F%2Fdevlinjunker.github.io%2Ftemplate.hapi.rest%2Fswagger%2Fopenapi.yaml)](https://devlinjunker.github.io/template.hapi.rest/swagger/)
-[![CII Best Practices Summary](https://img.shields.io/cii/summary/4288?label=core-infrastructure)](https://bestpractices.coreinfrastructure.org/en/projects/4288)
 [![ESDoc Status](https://raw.githubusercontent.com/devlinjunker/template.hapi.rest/master/docs/badge.svg)](https://devlinjunker.github.io/template.hapi.rest/source.html)
+[![CII Best Practices Summary](https://img.shields.io/cii/summary/4288?label=core-infrastructure)](https://bestpractices.coreinfrastructure.org/en/projects/4288)
+[![OpenAPI/Swagger Validator](https://img.shields.io/swagger/valid/3.0?label=openapi&specUrl=https%3A%2F%2Fdevlinjunker.github.io%2Ftemplate.hapi.rest%2Fswagger%2Fopenapi.yaml)](https://devlinjunker.github.io/template.hapi.rest/swagger/)  
+[![GitHub issues](https://img.shields.io/github/issues/devlinjunker/template.hapi.rest)](https://github.com/devlinjunker/template.hapi.rest/issues)
+[![GitHub issues by-label](https://img.shields.io/github/issues/devlinjunker/template.hapi.rest/-priority?color=red&label=priority%20issues)](https://github.com/devlinjunker/template.hapi.rest/issues?q=is%3Aopen+is%3Aissue+label%3A-priority)
 
 
 ## Intro

--- a/scripts/README.scripts.md
+++ b/scripts/README.scripts.md
@@ -23,9 +23,9 @@ For every PR against master, we spin up a server to build the project via node/w
 project at this point (with more stringent error rules?). This will help us catch any errors in the code and
 prevent any merges to master that will break
 
-## Github Specific Files
-Whenever a PR is made on Github, the body/description will be pre-populated with the contents in
-`.github/PULL_REQUEST_TEMPLATE.md`
+### Label Manager
+This project defines the Github Labels in a [YAML file](https://github.com/devlinjunker/template.hapi.rest/blob/master/.github/labels.yaml) that is managed by the [Github Labeler Action](https://github.com/marketplace/actions/github-labeler). 
+Any labels that are not defined in this file will be removed every time this action is run. **This does not affect PRs**
 
 ### On Merge to Master
 Whenever we merge a PR to master, we want to update the documentation based on the changes the user made in
@@ -33,6 +33,12 @@ the commits. We run a git action to handle this as well:
  - Collect README files and update wiki
  - Fix/remove links in Wiki
  - Build documentation and generate commit
+ 
+
+## Github Specific Files
+Whenever a PR is made on Github, the body/description will be pre-populated with the contents in
+`.github/PULL_REQUEST_TEMPLATE.md`
+
 
 ## Notes/Ideas
  - **IDEA:** Version increase/changelog generation


### PR DESCRIPTION
# Description:
Realized that `d93f0b` is a better color for `-priority` label.
Also wanted an easy way to link/see issues in README

# Related:
https://shields.io/category/issue-tracking

# Visual:
![Screen Shot 2020-10-09 at 4 47 23 PM](https://user-images.githubusercontent.com/1504590/95639953-47e7cd80-0a4f-11eb-94b4-977bbb61361a.png)

# TODO:
 - [x] Complete PR Body
 - [x] Updated Architecture/README documents
     - update wikis? 
